### PR TITLE
Adiciona testes para configurações e utilitários de tempo

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,88 @@
+"""Configurações globais de testes."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import IO, Iterator
+
+import pytest
+
+
+def _stub_dotenv_module() -> None:
+    if "dotenv" in sys.modules:
+        return
+
+    module = ModuleType("dotenv")
+
+    def find_dotenv(*, usecwd: bool = False) -> str:
+        return ""
+
+    def load_dotenv(*, dotenv_path: str | None = None, override: bool = False) -> bool:
+        if not dotenv_path:
+            return False
+        caminho = Path(dotenv_path)
+        if not caminho.exists():
+            return False
+        alterado = False
+        for linha in caminho.read_text(encoding="utf-8").splitlines():
+            if not linha or linha.lstrip().startswith("#") or "=" not in linha:
+                continue
+            chave, valor = linha.split("=", 1)
+            if override or chave not in os.environ:
+                os.environ[chave] = valor
+                alterado = True
+        return alterado
+
+    def set_key(dotenv_path: str, key: str, value: str) -> tuple[str, str, bool]:
+        caminho = Path(dotenv_path)
+        pares: dict[str, str] = {}
+        if caminho.exists():
+            for linha in caminho.read_text(encoding="utf-8").splitlines():
+                if not linha or linha.lstrip().startswith("#") or "=" not in linha:
+                    continue
+                atual_chave, atual_valor = linha.split("=", 1)
+                pares[atual_chave] = atual_valor
+        pares[key] = value
+        conteudo = "\n".join(f"{k}={v}" for k, v in pares.items())
+        caminho.write_text(conteudo, encoding="utf-8")
+        return key, value, True
+
+    def dotenv_values(
+        dotenv_path: str | os.PathLike[str] | None = None,
+        stream: IO[str] | None = None,
+        encoding: str | None = "utf-8",
+        *,
+        verbose: bool = False,
+        interpolate: bool = False,
+    ) -> dict[str, str]:
+        if stream is not None:
+            linhas = stream.read().splitlines()
+        elif dotenv_path:
+            caminho = Path(dotenv_path)
+            if not caminho.exists():
+                return {}
+            linhas = caminho.read_text(encoding=encoding or "utf-8").splitlines()
+        else:
+            return {}
+
+        pares: dict[str, str] = {}
+        for linha in linhas:
+            if not linha or linha.lstrip().startswith("#") or "=" not in linha:
+                continue
+            chave, valor = linha.split("=", 1)
+            pares[chave] = valor
+        return pares
+
+    module.find_dotenv = find_dotenv
+    module.load_dotenv = load_dotenv
+    module.set_key = set_key
+    module.dotenv_values = dotenv_values
+    sys.modules["dotenv"] = module
+
+
+@pytest.fixture(autouse=True)
+def _patch_dotenv() -> Iterator[None]:
+    _stub_dotenv_module()
+    yield

--- a/tests/unit/core/test_settings.py
+++ b/tests/unit/core/test_settings.py
@@ -1,0 +1,87 @@
+"""Testes para app.core.settings."""
+from __future__ import annotations
+
+from importlib import reload
+from pathlib import Path
+from types import ModuleType
+import sys
+
+import pytest
+
+
+def _ensure_src_in_path() -> None:
+    raiz = Path(__file__).resolve().parents[3] / "src"
+    if str(raiz) not in sys.path:
+        sys.path.insert(0, str(raiz))
+
+
+@pytest.fixture
+def settings_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Fornece o módulo de configurações com variáveis de ambiente controladas."""
+
+    _ensure_src_in_path()
+    env_values = {
+        "TIMEZONE_APP": "UTC",
+        "TIMEZONE_BUSINESS": "America/Sao_Paulo",
+        "POSTGRES_TZ": "America/Sao_Paulo",
+        "BLING_CLIENT_ID": "cliente", 
+        "BLING_CLIENT_SECRET": "segredo",
+        "BLING_USUARIO": "usuario",
+        "BLING_SENHA_USUARIO": "senha",
+        "BLING_BASEURL": "https://bling.example",
+        "POSTGRES_USER": "postgres",
+        "POSTGRES_PASSWORD": "postgres",
+        "POSTGRES_HOST": "localhost",
+        "POSTGRES_CONTAINER_PORT": "5432",
+        "POSTGRES_HOST_PORT": "5432",
+        "POSTGRES_DB": "bling",
+    }
+
+    for key, value in env_values.items():
+        monkeypatch.setenv(key, value)
+
+    for optional_key in {
+        "BLING_OAUTH_ACCESS_TOKEN",
+        "BLING_OAUTH_EXPIRES_IN",
+        "BLING_OAUTH_REFRESH_TOKEN",
+        "BLING_OAUTH_SCOPE",
+    }:
+        monkeypatch.delenv(optional_key, raising=False)
+
+    import app.core.settings as settings_module
+
+    reload(settings_module)
+    settings_module.get_settings.cache_clear()
+    return settings_module
+
+
+def test_get_settings_usa_variaveis_de_ambiente(settings_module) -> None:
+    settings = settings_module.get_settings()
+
+    assert settings.timezone_app == "UTC"
+    assert settings.bling_client_id == "cliente"
+    assert settings.postgres_container_port == 5432
+
+
+def test_validacao_timezone_invalido(settings_module, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TIMEZONE_APP", "Terra/Plana")
+    settings_module.get_settings.cache_clear()
+
+    with pytest.raises(ValueError, match="Unknown timezone"):
+        settings_module.get_settings()
+
+
+def test_set_settings_atualiza_env_e_limpa_cache(settings_module, tmp_path: Path) -> None:
+    settings_iniciais = settings_module.get_settings()
+    caminho_env = tmp_path / ".env.test"
+    caminho_env.touch()
+
+    novos = settings_module.set_settings({"TIMEZONE_APP": "Europe/London"}, env_path=str(caminho_env))
+
+    assert novos.timezone_app == "Europe/London"
+    assert novos is not settings_iniciais
+    assert caminho_env.read_text(encoding="utf-8").strip() == "TIMEZONE_APP=Europe/London"
+
+    # A chamada seguinte deve refletir o valor atualizado mantido em cache
+    atualizados = settings_module.get_settings()
+    assert atualizados.timezone_app == "Europe/London"

--- a/tests/unit/core/test_timeutil.py
+++ b/tests/unit/core/test_timeutil.py
@@ -1,0 +1,89 @@
+"""Testes para app.core.timeutil."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from importlib import reload
+from pathlib import Path
+from types import ModuleType
+import sys
+
+import pytest
+from zoneinfo import ZoneInfo
+
+
+def _ensure_src_in_path() -> None:
+    raiz = Path(__file__).resolve().parents[3] / "src"
+    if str(raiz) not in sys.path:
+        sys.path.insert(0, str(raiz))
+
+
+@pytest.fixture
+def timeutil_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Carrega o módulo de utilitários de tempo com ambientes controlados."""
+
+    _ensure_src_in_path()
+    monkeypatch.setenv("TIMEZONE_APP", "UTC")
+    monkeypatch.setenv("TIMEZONE_BUSINESS", "America/Sao_Paulo")
+    monkeypatch.setenv("POSTGRES_TZ", "America/Sao_Paulo")
+    monkeypatch.setenv("BLING_CLIENT_ID", "cliente")
+    monkeypatch.setenv("BLING_CLIENT_SECRET", "segredo")
+    monkeypatch.setenv("BLING_USUARIO", "usuario")
+    monkeypatch.setenv("BLING_SENHA_USUARIO", "senha")
+    monkeypatch.setenv("BLING_BASEURL", "https://bling.example")
+    monkeypatch.setenv("POSTGRES_USER", "postgres")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "postgres")
+    monkeypatch.setenv("POSTGRES_HOST", "localhost")
+    monkeypatch.setenv("POSTGRES_CONTAINER_PORT", "5432")
+    monkeypatch.setenv("POSTGRES_HOST_PORT", "5432")
+    monkeypatch.setenv("POSTGRES_DB", "bling")
+
+    import app.core.settings as settings_module
+
+    reload(settings_module)
+    settings_module.get_settings.cache_clear()
+
+    import app.core.timeutil as timeutil
+
+    reload(timeutil)
+    return timeutil
+
+
+def test_time_now_retorna_em_utc(timeutil_module: ModuleType) -> None:
+    agora = timeutil_module.time_now()
+
+    assert agora.tzinfo is timezone.utc
+
+
+def test_time_to_utc_converte_zoneado(timeutil_module: ModuleType) -> None:
+    zona_sp = ZoneInfo("America/Sao_Paulo")
+    dt = datetime(2024, 5, 10, 12, 30, tzinfo=zona_sp)
+
+    convertido = timeutil_module.time_to_utc(dt)
+
+    assert convertido.tzinfo is timezone.utc
+    assert convertido.hour == 15  # UTC é +3 em maio para São Paulo
+
+
+def test_time_to_utc_exige_tzinfo(timeutil_module: ModuleType) -> None:
+    dt_naive = datetime(2024, 5, 10, 12, 30)
+
+    with pytest.raises(ValueError):
+        timeutil_module.time_to_utc(dt_naive)
+
+
+def test_time_to_business_converte_para_fuso(timeutil_module: ModuleType) -> None:
+    dt_utc = datetime(2024, 5, 10, 15, 30, tzinfo=timezone.utc)
+
+    convertido = timeutil_module.time_to_business(dt_utc)
+
+    assert convertido.tzinfo == ZoneInfo("America/Sao_Paulo")
+    assert convertido.hour == 12
+
+
+def test_iso_z_formata_com_sufixo_z(timeutil_module: ModuleType) -> None:
+    dt = datetime(2024, 5, 10, 12, 30, tzinfo=ZoneInfo("America/Sao_Paulo"))
+
+    resultado = timeutil_module.iso_z(dt)
+
+    assert resultado.endswith("Z")
+    assert "T" in resultado


### PR DESCRIPTION
## Resumo
- cria um `conftest` que injeta um stub mínimo de `python-dotenv` quando o pacote não está instalado
- adiciona testes unitários para `app.core.settings`, validando carregamento, validações de timezone e atualização via `set_settings`
- adiciona testes unitários para `app.core.timeutil`, cobrindo conversões e formatação de datas

## Testes
- `pytest tests/unit/core`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb35a49388320b5747f49869430ed)