### PR TITLE
Adiciona testes do fluxo OAuth e ajusta stubs de dependências

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,148 @@
+"""Configurações globais de testes."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import IO, Iterator
+
+import pytest
+
+
+def _stub_dotenv_module() -> None:
+    if "dotenv" in sys.modules:
+        return
+    try:  # pragma: no cover - comportamento real
+        __import__("dotenv")
+    except ModuleNotFoundError:
+        pass
+    else:
+        return
+
+    module = ModuleType("dotenv")
+
+    def find_dotenv(*, usecwd: bool = False) -> str:
+        return ""
+
+    def load_dotenv(*, dotenv_path: str | None = None, override: bool = False) -> bool:
+        if not dotenv_path:
+            return False
+        caminho = Path(dotenv_path)
+        if not caminho.exists():
+            return False
+        alterado = False
+        for linha in caminho.read_text(encoding="utf-8").splitlines():
+            if not linha or linha.lstrip().startswith("#") or "=" not in linha:
+                continue
+            chave, valor = linha.split("=", 1)
+            if override or chave not in os.environ:
+                os.environ[chave] = valor
+                alterado = True
+        return alterado
+
+    def set_key(dotenv_path: str, key: str, value: str) -> tuple[str, str, bool]:
+        caminho = Path(dotenv_path)
+        pares: dict[str, str] = {}
+        if caminho.exists():
+            for linha in caminho.read_text(encoding="utf-8").splitlines():
+                if not linha or linha.lstrip().startswith("#") or "=" not in linha:
+                    continue
+                atual_chave, atual_valor = linha.split("=", 1)
+                pares[atual_chave] = atual_valor
+        pares[key] = value
+        conteudo = "\n".join(f"{k}={v}" for k, v in pares.items())
+        caminho.write_text(conteudo, encoding="utf-8")
+        return key, value, True
+
+    def dotenv_values(
+        dotenv_path: str | os.PathLike[str] | None = None,
+        stream: IO[str] | None = None,
+        encoding: str | None = "utf-8",
+        *,
+        verbose: bool = False,
+        interpolate: bool = False,
+    ) -> dict[str, str]:
+        if stream is not None:
+            linhas = stream.read().splitlines()
+        elif dotenv_path:
+            caminho = Path(dotenv_path)
+            if not caminho.exists():
+                return {}
+            linhas = caminho.read_text(encoding=encoding or "utf-8").splitlines()
+        else:
+            return {}
+
+        pares: dict[str, str] = {}
+        for linha in linhas:
+            if not linha or linha.lstrip().startswith("#") or "=" not in linha:
+                continue
+            chave, valor = linha.split("=", 1)
+            pares[chave] = valor
+        return pares
+
+    module.find_dotenv = find_dotenv
+    module.load_dotenv = load_dotenv
+    module.set_key = set_key
+    module.dotenv_values = dotenv_values
+    sys.modules["dotenv"] = module
+
+
+def _stub_requests_module() -> None:
+    if "requests" in sys.modules:
+        return
+    try:  # pragma: no cover - comportamento real
+        __import__("requests")
+    except ModuleNotFoundError:
+        pass
+    else:
+        return
+
+    module = ModuleType("requests")
+
+    class RequestException(Exception):
+        """Exceção base para falhas simuladas do requests."""
+
+    class Session:
+        """Sessão HTTP mínima para ser usada como spec em mocks."""
+
+        def post(self, *args: object, **kwargs: object) -> object:  # pragma: no cover
+            raise NotImplementedError
+
+        def request(self, *args: object, **kwargs: object) -> object:  # pragma: no cover
+            raise NotImplementedError
+
+    auth_module = ModuleType("requests.auth")
+
+    class HTTPBasicAuth:  # pragma: no cover - comportamento trivial
+        def __init__(self, username: str, password: str) -> None:
+            self.username = username
+            self.password = password
+
+    auth_module.HTTPBasicAuth = HTTPBasicAuth
+
+    class Response:
+        status_code = 200
+        text = ""
+
+        def json(self) -> object:  # pragma: no cover - comportamento trivial
+            return {}
+
+    module.RequestException = RequestException
+    module.Session = Session
+    module.Response = Response
+    module.auth = auth_module
+
+    sys.modules["requests"] = module
+    sys.modules["requests.auth"] = auth_module
+
+
+_stub_dotenv_module()
+_stub_requests_module()
+
+
+@pytest.fixture(autouse=True)
+def _patch_dotenv() -> Iterator[None]:
+    _stub_dotenv_module()
+    _stub_requests_module()
+    yield

--- a/tests/unit/core/test_settings.py
+++ b/tests/unit/core/test_settings.py
@@ -1,0 +1,92 @@
+"""Testes para app.core.settings."""
+from __future__ import annotations
+
+from importlib import reload
+from pathlib import Path
+from types import ModuleType
+import sys
+
+import pytest
+
+
+def _ensure_src_in_path() -> None:
+    raiz = Path(__file__).resolve().parents[3] / "src"
+    if str(raiz) not in sys.path:
+        sys.path.insert(0, str(raiz))
+
+
+@pytest.fixture
+def settings_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Fornece o módulo de configurações com variáveis de ambiente controladas."""
+
+    _ensure_src_in_path()
+    env_values = {
+        "TIMEZONE_APP": "UTC",
+        "TIMEZONE_BUSINESS": "America/Sao_Paulo",
+        "POSTGRES_TZ": "America/Sao_Paulo",
+        "BLING_CLIENT_ID": "cliente", 
+        "BLING_CLIENT_SECRET": "segredo",
+        "BLING_USUARIO": "usuario",
+        "BLING_SENHA_USUARIO": "senha",
+        "BLING_BASEURL": "https://bling.example",
+        "POSTGRES_USER": "postgres",
+        "POSTGRES_PASSWORD": "postgres",
+        "POSTGRES_HOST": "localhost",
+        "POSTGRES_CONTAINER_PORT": "5432",
+        "POSTGRES_HOST_PORT": "5432",
+        "POSTGRES_DB": "bling",
+    }
+
+    for key, value in env_values.items():
+        monkeypatch.setenv(key, value)
+
+    for optional_key in {
+        "BLING_OAUTH_ACCESS_TOKEN",
+        "BLING_OAUTH_EXPIRES_IN",
+        "BLING_OAUTH_REFRESH_TOKEN",
+        "BLING_OAUTH_SCOPE",
+    }:
+        monkeypatch.delenv(optional_key, raising=False)
+
+    import app.core.settings as settings_module
+
+    reload(settings_module)
+    settings_module.get_settings.cache_clear()
+    return settings_module
+
+
+def test_get_settings_usa_variaveis_de_ambiente(settings_module) -> None:
+    settings = settings_module.get_settings()
+
+    assert settings.timezone_app == "UTC"
+    assert settings.bling_client_id == "cliente"
+    assert settings.postgres_container_port == 5432
+
+
+def test_validacao_timezone_invalido(settings_module, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TIMEZONE_APP", "Terra/Plana")
+    settings_module.get_settings.cache_clear()
+
+    with pytest.raises(ValueError, match="Unknown timezone"):
+        settings_module.get_settings()
+
+
+def test_set_settings_atualiza_env_e_limpa_cache(settings_module, tmp_path: Path) -> None:
+    settings_iniciais = settings_module.get_settings()
+    caminho_env = tmp_path / ".env.test"
+    caminho_env.touch()
+
+    novos = settings_module.set_settings({"TIMEZONE_APP": "Europe/London"}, env_path=str(caminho_env))
+
+    assert novos.timezone_app == "Europe/London"
+    assert novos is not settings_iniciais
+    conteudo_env = caminho_env.read_text(encoding="utf-8").strip()
+    assert conteudo_env in {
+        "TIMEZONE_APP=Europe/London",
+        "TIMEZONE_APP='Europe/London'",
+        'TIMEZONE_APP="Europe/London"',
+    }
+
+    # A chamada seguinte deve refletir o valor atualizado mantido em cache
+    atualizados = settings_module.get_settings()
+    assert atualizados.timezone_app == "Europe/London"

--- a/tests/unit/core/test_timeutil.py
+++ b/tests/unit/core/test_timeutil.py
@@ -1,0 +1,89 @@
+"""Testes para app.core.timeutil."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from importlib import reload
+from pathlib import Path
+from types import ModuleType
+import sys
+
+import pytest
+from zoneinfo import ZoneInfo
+
+
+def _ensure_src_in_path() -> None:
+    raiz = Path(__file__).resolve().parents[3] / "src"
+    if str(raiz) not in sys.path:
+        sys.path.insert(0, str(raiz))
+
+
+@pytest.fixture
+def timeutil_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Carrega o módulo de utilitários de tempo com ambientes controlados."""
+
+    _ensure_src_in_path()
+    monkeypatch.setenv("TIMEZONE_APP", "UTC")
+    monkeypatch.setenv("TIMEZONE_BUSINESS", "America/Sao_Paulo")
+    monkeypatch.setenv("POSTGRES_TZ", "America/Sao_Paulo")
+    monkeypatch.setenv("BLING_CLIENT_ID", "cliente")
+    monkeypatch.setenv("BLING_CLIENT_SECRET", "segredo")
+    monkeypatch.setenv("BLING_USUARIO", "usuario")
+    monkeypatch.setenv("BLING_SENHA_USUARIO", "senha")
+    monkeypatch.setenv("BLING_BASEURL", "https://bling.example")
+    monkeypatch.setenv("POSTGRES_USER", "postgres")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "postgres")
+    monkeypatch.setenv("POSTGRES_HOST", "localhost")
+    monkeypatch.setenv("POSTGRES_CONTAINER_PORT", "5432")
+    monkeypatch.setenv("POSTGRES_HOST_PORT", "5432")
+    monkeypatch.setenv("POSTGRES_DB", "bling")
+
+    import app.core.settings as settings_module
+
+    reload(settings_module)
+    settings_module.get_settings.cache_clear()
+
+    import app.core.timeutil as timeutil
+
+    reload(timeutil)
+    return timeutil
+
+
+def test_time_now_retorna_em_utc(timeutil_module: ModuleType) -> None:
+    agora = timeutil_module.time_now()
+
+    assert agora.tzinfo is timezone.utc
+
+
+def test_time_to_utc_converte_zoneado(timeutil_module: ModuleType) -> None:
+    zona_sp = ZoneInfo("America/Sao_Paulo")
+    dt = datetime(2024, 5, 10, 12, 30, tzinfo=zona_sp)
+
+    convertido = timeutil_module.time_to_utc(dt)
+
+    assert convertido.tzinfo is timezone.utc
+    assert convertido.hour == 15  # UTC é +3 em maio para São Paulo
+
+
+def test_time_to_utc_exige_tzinfo(timeutil_module: ModuleType) -> None:
+    dt_naive = datetime(2024, 5, 10, 12, 30)
+
+    with pytest.raises(ValueError):
+        timeutil_module.time_to_utc(dt_naive)
+
+
+def test_time_to_business_converte_para_fuso(timeutil_module: ModuleType) -> None:
+    dt_utc = datetime(2024, 5, 10, 15, 30, tzinfo=timezone.utc)
+
+    convertido = timeutil_module.time_to_business(dt_utc)
+
+    assert convertido.tzinfo == ZoneInfo("America/Sao_Paulo")
+    assert convertido.hour == 12
+
+
+def test_iso_z_formata_com_sufixo_z(timeutil_module: ModuleType) -> None:
+    dt = datetime(2024, 5, 10, 12, 30, tzinfo=ZoneInfo("America/Sao_Paulo"))
+
+    resultado = timeutil_module.iso_z(dt)
+
+    assert resultado.endswith("Z")
+    assert "T" in resultado

--- a/tests/unit/services/bling/test_oauth.py
+++ b/tests/unit/services/bling/test_oauth.py
@@ -1,0 +1,286 @@
+"""Testes para app.services.bling.oauth."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from importlib import reload
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Mapping
+import sys
+
+import pytest
+import requests
+from unittest.mock import Mock
+
+
+def _ensure_src_in_path() -> None:
+    caminho_teste = Path(__file__).resolve()
+    for parent in caminho_teste.parents:
+        candidato = parent / "src"
+        if candidato.exists():
+            if str(candidato) not in sys.path:
+                sys.path.insert(0, str(candidato))
+            return
+    raise RuntimeError("Diretório 'src' não encontrado na hierarquia de testes")
+
+
+@pytest.fixture
+def oauth_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Fornece o módulo de OAuth com dependências recarregadas."""
+
+    _ensure_src_in_path()
+    env_values = {
+        "TIMEZONE_APP": "UTC",
+        "TIMEZONE_BUSINESS": "America/Sao_Paulo",
+        "POSTGRES_TZ": "America/Sao_Paulo",
+        "BLING_CLIENT_ID": "cliente",
+        "BLING_CLIENT_SECRET": "segredo",
+        "BLING_USUARIO": "usuario",
+        "BLING_SENHA_USUARIO": "senha",
+        "BLING_BASEURL": "https://bling.example",
+        "POSTGRES_USER": "postgres",
+        "POSTGRES_PASSWORD": "postgres",
+        "POSTGRES_HOST": "localhost",
+        "POSTGRES_CONTAINER_PORT": "5432",
+        "POSTGRES_HOST_PORT": "5432",
+        "POSTGRES_DB": "bling",
+        "BLING_OAUTH_REFRESH_TOKEN": "token_atual",
+    }
+
+    for key, value in env_values.items():
+        monkeypatch.setenv(key, value)
+
+    for optional in {
+        "BLING_OAUTH_ACCESS_TOKEN",
+        "BLING_OAUTH_EXPIRES_IN",
+        "BLING_OAUTH_SCOPE",
+    }:
+        monkeypatch.delenv(optional, raising=False)
+
+    import app.core.settings as settings_module
+
+    reload(settings_module)
+    settings_module.get_settings.cache_clear()
+
+    import app.core.timeutil as timeutil_module
+
+    reload(timeutil_module)
+
+    import app.services.bling.oauth as oauth
+
+    reload(oauth)
+    return oauth
+
+
+@pytest.fixture
+def settings(oauth_module: ModuleType) -> Any:
+    return oauth_module.get_settings()
+
+
+def test_oauth_token_serializa_e_calcula_expiracao(
+    oauth_module: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    instante = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(oauth_module, "time_now", lambda: instante)
+
+    token = oauth_module.OAuthToken(
+        access_token="abc123",
+        expires_in=3600,
+        token_type="Bearer",
+        scope="perfil",
+        refresh_token="refresh123",
+        obtained_at=instante,
+    )
+
+    esperado = oauth_module.time_to_business(
+        instante + timedelta(seconds=token.expires_in)
+    )
+    assert token.expires_at == esperado
+
+    serializado = token.model_dump(by_alias=True)
+    assert serializado["access_token"] == "abc123"
+    assert serializado["expires_in"] == 3600
+
+    monkeypatch.setattr(oauth_module, "time_now", lambda: instante + timedelta(seconds=3599))
+    assert token.is_expired(leeway=0) is False
+
+    monkeypatch.setattr(oauth_module, "time_now", lambda: instante + timedelta(seconds=3600))
+    assert token.is_expired(leeway=0) is True
+
+
+def test_get_token_renova_automaticamente_quando_expira(
+    oauth_module: ModuleType,
+    settings: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cliente = oauth_module.BlingOAuthClient(settings=settings)
+
+    instante = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    expirado = oauth_module.OAuthToken(
+        access_token="antigo",
+        expires_in=10,
+        token_type="Bearer",
+        refresh_token="token_atual",
+        obtained_at=instante,
+    )
+    cliente._token = expirado
+
+    novo_token = oauth_module.OAuthToken(
+        access_token="novo",
+        expires_in=3600,
+        token_type="Bearer",
+        refresh_token="token_atualizado",
+        obtained_at=instante + timedelta(seconds=20),
+    )
+
+    chamada = {"executada": 0}
+
+    def _falso_refresh(*, save_to_env: bool = True) -> oauth_module.OAuthToken:
+        chamada["executada"] += 1
+        return novo_token
+
+    monkeypatch.setattr(cliente, "refresh_access_token", _falso_refresh)
+    monkeypatch.setattr(
+        oauth_module,
+        "time_now",
+        lambda: instante + timedelta(seconds=600),
+    )
+
+    resultado = cliente.get_token()
+
+    assert resultado is novo_token
+    assert chamada["executada"] == 1
+    assert cliente._token is novo_token
+
+    resultado_forcado = cliente.get_token(force_refresh=True)
+    assert resultado_forcado is novo_token
+    assert chamada["executada"] == 2
+
+
+def test_refresh_access_token_sem_refresh_token_dispara_erro(
+    oauth_module: ModuleType, settings: Any
+) -> None:
+    cliente = oauth_module.BlingOAuthClient(settings=settings)
+    cliente._refresh_token = None
+
+    with pytest.raises(oauth_module.BlingOAuthError, match="Refresh token inexistente"):
+        cliente.refresh_access_token()
+
+
+def test_refresh_access_token_persiste_token_quando_configurado(
+    oauth_module: ModuleType,
+    settings: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cliente = oauth_module.BlingOAuthClient(settings=settings)
+
+    token_atualizado = oauth_module.OAuthToken(
+        access_token="novo",
+        expires_in=1800,
+        token_type="Bearer",
+        scope="perfil",
+        refresh_token="novo_refresh",
+        obtained_at=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+    )
+
+    monkeypatch.setattr(cliente, "_request_token", lambda payload: token_atualizado)
+
+    capturado: dict[str, Mapping[str, str | None]] = {}
+
+    def _falso_set_settings(
+        valores: Mapping[str, str | None],
+        *,
+        env_path: str | None = None,
+    ) -> Any:
+        capturado["dados"] = valores
+        return settings
+
+    monkeypatch.setattr(oauth_module, "set_settings", _falso_set_settings)
+
+    resultado = cliente.refresh_access_token(save_to_env=True)
+
+    assert resultado is token_atualizado
+    assert capturado["dados"][cliente.ENV_ACCESS_TOKEN_KEY] == "novo"
+    assert capturado["dados"][cliente.ENV_REFRESH_TOKEN_KEY] == "novo_refresh"
+    assert cliente._refresh_token == "novo_refresh"
+
+
+def test_request_token_trata_erros_de_rede(
+    oauth_module: ModuleType, settings: Any
+) -> None:
+    sessao = Mock(spec=requests.Session)
+    sessao.post.side_effect = requests.RequestException("falhou")
+
+    cliente = oauth_module.BlingOAuthClient(settings=settings, session=sessao)
+
+    with pytest.raises(oauth_module.BlingOAuthError, match="Falha ao se comunicar"):
+        cliente._request_token({"grant_type": "refresh_token"})
+
+
+def test_request_token_com_status_de_erro_gera_excecao(
+    oauth_module: ModuleType, settings: Any
+) -> None:
+    class RespostaErro:
+        status_code = 401
+        text = "{\"erro\": \"invalid_client\"}"
+
+        def json(self) -> Mapping[str, Any]:
+            return {"erro": "invalid_client"}
+
+    sessao = Mock(spec=requests.Session)
+    sessao.post.return_value = RespostaErro()
+
+    cliente = oauth_module.BlingOAuthClient(settings=settings, session=sessao)
+
+    with pytest.raises(oauth_module.BlingOAuthError, match="status 401"):
+        cliente._request_token({"grant_type": "refresh_token"})
+
+
+def test_request_token_rejeita_json_invalido(
+    oauth_module: ModuleType, settings: Any
+) -> None:
+    class RespostaFalsa:
+        status_code = 200
+        text = "<<<não é json>>>"
+
+        def json(self) -> Mapping[str, Any]:
+            raise ValueError("inválido")
+
+    sessao = Mock(spec=requests.Session)
+    sessao.post.return_value = RespostaFalsa()
+
+    cliente = oauth_module.BlingOAuthClient(settings=settings, session=sessao)
+
+    with pytest.raises(oauth_module.BlingOAuthError, match="Resposta inesperada"):
+        cliente._request_token({"grant_type": "refresh_token"})
+
+
+def test_exchange_code_for_token_atualiza_refresh(
+    oauth_module: ModuleType,
+    settings: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cliente = oauth_module.BlingOAuthClient(settings=settings)
+    cliente._refresh_token = "antigo_refresh"
+
+    token_novo = oauth_module.OAuthToken(
+        access_token="novo",
+        expires_in=1800,
+        token_type="Bearer",
+        refresh_token="refresh_trocado",
+        obtained_at=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+    )
+
+    monkeypatch.setattr(cliente, "_request_token", lambda payload: token_novo)
+    persistido = {"executado": False}
+
+    def _falso_persistir(token: oauth_module.OAuthToken) -> None:
+        persistido["executado"] = True
+
+    monkeypatch.setattr(cliente, "_persist_token", _falso_persistir)
+
+    resultado = cliente.exchange_code_for_token("codigo", save_to_env=False)
+
+    assert resultado is token_novo
+    assert cliente._refresh_token == "refresh_trocado"
+    assert persistido["executado"] is False


### PR DESCRIPTION
## Resumo
- adiciona suíte de testes unitários para o fluxo OAuth do Bling, cobrindo serialização do token, renovação automática e cenários de erro
- ajusta o `conftest` para só aplicar stubs de `dotenv` e `requests` quando as dependências reais não estiverem disponíveis
- atualiza o teste de `set_settings` para aceitar o formato de escrita usado pelo `python-dotenv`

## Testes
- pytest tests/unit/core tests/unit/services/bling/test_oauth.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb35a49388320b5747f49869430ed)